### PR TITLE
Removed qemu incompatible packages to avoid error installing libc-bin

### DIFF
--- a/docker/zms/Dockerfile
+++ b/docker/zms/Dockerfile
@@ -56,7 +56,8 @@ LABEL org.opencontainers.image.source="https://github.com/ctyano/athenz-distribu
 
 #RUN apk add --no-cache bash
 RUN apt-get update
-RUN apt-get -y install bash curl net-tools netcat openssl tree git jq tzdata wget ca-certificates-java
+#RUN apt-get -y install bash curl net-tools netcat openssl tree git jq tzdata wget ca-certificates-java
+RUN apt-get -y install tzdata
 RUN apt-get clean
 RUN apt-get autoremove
 

--- a/docker/zts/Dockerfile
+++ b/docker/zts/Dockerfile
@@ -56,7 +56,8 @@ LABEL org.opencontainers.image.source="https://github.com/ctyano/athenz-distribu
 
 #RUN apk add --no-cache bash
 RUN apt-get update
-RUN apt-get -y install bash curl net-tools netcat openssl tree git jq tzdata wget ca-certificates-java
+#RUN apt-get -y install bash curl net-tools netcat openssl tree git jq tzdata wget ca-certificates-java
+RUN apt-get -y install tzdata
 RUN apt-get clean
 RUN apt-get autoremove
 


### PR DESCRIPTION
## Type of changes

Choose one of the below, or leave them empty:

- [ ] New feature proposal
- [x] Bug fix
- [x] Minor improvements
- [ ] Refactoring (no functional changes)
- [ ] Non-code changes (updating documentation, workflows, etc.)

## Background

```
21.21 Processing triggers for libc-bin (2.31-13+deb11u8) ...
21.25 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
21.26 Segmentation fault
21.26 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
21.26 Segmentation fault
21.27 dpkg: error processing package libc-bin (--configure):
21.27  installed libc-bin package post-installation script subprocess returned error exit status 139
21.28 Errors were encountered while processing:
21.28  libc-bin
21.38 E: Sub-process /usr/bin/dpkg returned an error code (1)
```